### PR TITLE
Switch January 2023 post to live and update links

### DIFF
--- a/www/blog/2023-01-23-thismonth/index.md
+++ b/www/blog/2023-01-23-thismonth/index.md
@@ -3,7 +3,7 @@ slug: roundup-2023-jan
 title: "SWA Roundup: Jan 2023"
 authors: [reshmi, nitya, sara]
 tags: [swa, thismonth, jan]
-draft: true
+draft: false
 ---
 
 <head>

--- a/www/blog/2023-01-23-thismonth/index.md
+++ b/www/blog/2023-01-23-thismonth/index.md
@@ -82,7 +82,7 @@ _Each month, we hope to turn the spotlight on one key resource or person that is
 
 :::info 🌟 SPOTLIGHT ON:  SWA CLI
 
-[Static Web Apps CLI](https://azure.github.io/static-web-apps-cli/) is an all-in-one local development tool For Azure Static Web Apps. Using SWA CLI you can deploy your apps right from your local enviroment to the Azure cloud without a CI/CD workflow, and instead a simple CLI command. 
+[**Static Web Apps CLI**](https://azure.github.io/static-web-apps-cli/) is an all-in-one local development tool For Azure Static Web Apps. Using SWA CLI you can deploy your apps right from your local enviroment to the Azure cloud without a CI/CD workflow, and instead a simple CLI command. 
 
 From the SWA CLI you can login to Azure subscriptions, initialize an Azure Static Web Apps project, set build configurations, and deploy your app.
 

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -20,7 +20,7 @@ function HomepageHeader() {
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         */}
         <h3> #ThisMonthInSWA - Jan 2023! </h3>
-        <Link to="blog/roundup-2022-nov">
+        <Link to="blog/roundup-2023-jan">
           <Image img={bannerImg} className={styles.featureImg} />
         </Link>
         <h5>Click the image to read the latest issue!</h5>

--- a/www/src/pages/thismonth.md
+++ b/www/src/pages/thismonth.md
@@ -7,7 +7,7 @@ title: This Month In SWA
 Welcome to `This Month In SWA` - a monthly roundup of [Azure Static Web Apps](https://docs.microsoft.com/en-us/azure/static-web-apps/overview) news and updates from the Product Team, Cloud & Student Advocacy - and from you, our amazing Developer Community. 
 
 [**Click here to read the latest issue**
-![](../../static/img/png/roundup/nov.png)](/blog/roundup-2022-nov)
+![](../../static/img/png/roundup/jan.png)](/blog/roundup-2023-jan)
 
 
 ---


### PR DESCRIPTION
Updates the roundup links to point to January 2023 post and takes Jan roundup out of draft. 